### PR TITLE
Hail: make comment colour lighter

### DIFF
--- a/gerane.Theme-Hail/themes/Hail.tmTheme
+++ b/gerane.Theme-Hail/themes/Hail.tmTheme
@@ -53,7 +53,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#7a8ba2</string>
+				<string>#526479</string>
 			</dict>
 		</dict>
 		<dict>

--- a/gerane.Theme-Hail/themes/Hail.tmTheme
+++ b/gerane.Theme-Hail/themes/Hail.tmTheme
@@ -53,7 +53,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#324357</string>
+				<string>#7a8ba2</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Comments are barely visible when near normal text. Make them lighter for better visibility.