### PR TITLE
Brogrammer: Added JSX support.

### DIFF
--- a/gerane.Theme-Brogrammer/themes/Brogrammer.tmTheme
+++ b/gerane.Theme-Brogrammer/themes/Brogrammer.tmTheme
@@ -284,6 +284,28 @@
             </dict>
         </dict>
         <dict>
+			<key>name</key>
+			<string>Javascript object literal separator</string>
+			<key>scope</key>
+			<string>punctuation.separator.key-value.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#6c71c4</string>
+			</dict>
+		</dict>
+        <dict>
+			<key>name</key>
+			<string>Javascript object literal key</string>
+			<key>scope</key>
+			<string>meta.object-literal.key.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f1c40f</string>
+			</dict>
+		</dict>
+        <dict>
             <key>name</key>
             <string>Tag name</string>
             <key>scope</key>

--- a/gerane.Theme-Brogrammer/themes/Brogrammer.tmTheme
+++ b/gerane.Theme-Brogrammer/themes/Brogrammer.tmTheme
@@ -285,6 +285,28 @@
         </dict>
         <dict>
             <key>name</key>
+            <string>Tag name</string>
+            <key>scope</key>
+            <string>entity.name.tag</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#e74c3c</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Tag attribute</string>
+            <key>scope</key>
+            <string>entity.other.attribute-name</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#2ecc71</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Meta.tag.A</string>
             <key>scope</key>
             <string>declaration.tag, declaration.tag entity, meta.tag, meta.tag entity</string>


### PR DESCRIPTION
Hi, I recently switched from Sublime to VS Code and I am used the brogrammer theme, so thanks for setting all these up!

I just needed JSX syntax highlighting which I had in Sublime, so I added 'entity.tag.name' which will make all  html-like tag names the theme's reddish color, and 'entity.other.attribute-name', which makes all tag attributes the theme's green color, which matches the version available in sublime. 

The only difference I could notice for other file types is that now HTML, XML, etc. tag names and tag attributes are different colors, and previously they were the same, but for me this looks a little better.