### PR TITLE
Invalid attribute for key element

### DIFF
--- a/gerane.Theme-Welded/themes/Welded.tmTheme
+++ b/gerane.Theme-Welded/themes/Welded.tmTheme
@@ -237,7 +237,7 @@
 			</dict>
 		</dict>
 		<dict>
-			<key a="asd">name</key>
+			<key>name</key>
 			<string>Tag attribute</string>
 			<key>scope</key>
 			<string>entity.other.attribute-name</string>


### PR DESCRIPTION
The attribute "a" seems to prevent Visual Studio Code from successfully loading the theme.