### PR TITLE
Update Abyss.tmTheme to color invalid code red fixes #85

### DIFF
--- a/gerane.Theme-Abyss/themes/Abyss.tmTheme
+++ b/gerane.Theme-Abyss/themes/Abyss.tmTheme
@@ -266,7 +266,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#F8F8F0</string>
+				<string>#F44747</string>
 			</dict>
 		</dict>
 		<dict>
@@ -279,7 +279,7 @@
 				<key>background</key>
 				<string>#AE81FF</string>
 				<key>foreground</key>
-				<string>#F8F8F0</string>
+				<string>#F44747</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
1)  This modifies this built in VS Code theme to comply with the red-means-invalid convention implemented in built in VS Code Themes including the Default Dark Default Dark+.
2)  This change applies the widely accepted convention that red means stop or danger to invalid code.  It also draws a clearer contrast between invalid syntax and routine, valid syntax.